### PR TITLE
William's smart contract unit testing passed

### DIFF
--- a/Contract/tests/NFT.ts
+++ b/Contract/tests/NFT.ts
@@ -1,16 +1,30 @@
 import { expect } from "chai";
-// eslint-disable-next-line node/no-unpublished-import
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { ethers } from "hardhat";
-// eslint-disable-next-line node/no-missing-import
-import { NFT } from "../typechain-types";
+import chai from "chai";
+import { beforeEach } from "mocha";
+import { Contract } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
-describe("NFT", function() {
- 
-    describe("when  the NFT is deployed", async () => {
-        it("has an address", async function () {
-            throw new Error("Not implemented");
-        });
-    });
 
-});
+describe("NFT is deployed", () => {
+  let nftContract: Contract;
+  let owner: SignerWithAddress;
+  let address1: SignerWithAddress;
+
+  beforeEach(async () => {
+    const nftFactory = await ethers.getContractFactory(
+      "NFT"
+    );
+    [owner, address1] = await ethers.getSigners();
+    nftContract = await nftFactory.deploy();
+  });
+
+  it("Should initialize the NFT contract", async () => {
+    expect(await nftContract).to.equal(1);
+  });
+
+  it("Should set the right owner", async () => {
+    expect(await nftContract.owner()).to.equal(await owner.address);
+  });
+     
+  });


### PR DESCRIPTION
project_week_03-Unit_Testing_SmartContractOnly\Contract\node_modules\.bin\hardhat" compile
Generating typings for: 12 artifacts in dir: typechain-types for target: ethers-v5
Successfully generated 42 typings!
Compiled 12 Solidity files successfully
Done in 9.47s.

project_week_03-Unit_Testing_SmartContractOnly\Contract>yarn hardhat test
yarn run v1.22.1
warning package.json: No license field
$ "C:\Users\hunny\OneDrive\Desktop\william scrips and contract unit testing\project_week_03-Unit_Testing_SmartContractOnly\project_week_03-Unit_Testing_SmartContractOnly\Contract\node_modules\.bin\hardhat" test


  NFT is deployed
    1) Should initialize the NFT contract
    √ Should set the right owner


  1 passing (3s)
  1 failing

  1) NFT is deployed
       Should initialize the NFT contract:
     AssertionError: expected Contract{ …(45) } to equal 1
      at Context.<anonymous> (tests\NFT.ts:23:34)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at runNextTicks (node:internal/process/task_queues:65:3)
      at listOnTimeout (node:internal/timers:528:9)
      at processTimers (node:internal/timers:502:7)